### PR TITLE
feat: Add support for Original Creditor Scheme ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ info.creditorIBAN = "DE87123456781234567890";
 info.creditorBIC = "XMPLDEM0XXX";
 info.creditorName = "Example LLC";
 info.creditorId = "DE98ZZZ09999999999";
+info.originalCreditorId = "DE98ZZZ09999999999"; //optional, for creditor ID migrations
 info.batchBooking = true; //optional
 doc.addPaymentInfo(info);
 

--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -287,6 +287,9 @@
     /** Id assigned to the creditor */
     creditorId: '',
 
+    /** Original creditor id (optional, for creditor id migrations) */
+    originalCreditorId: null,
+
     /** Name, Address, IBAN and BIC of the creditor */
     creditorName: '',
     creditorStreet: null,
@@ -365,6 +368,10 @@
 
       if (this[pullFrom + 'Id']) {
         assert_cid(this[pullFrom + 'Id'], pullFrom + 'Id');
+      }
+
+      if (this.originalCreditorId) {
+        assert_cid(this.originalCreditorId, 'originalCreditorId');
       }
 
       assert_length(this[pullFrom + 'Name'], null, 70, pullFrom + 'Name');
@@ -446,6 +453,12 @@
         var creditorScheme = n(pmtInf, 'CdtrSchmeId', 'Id', 'PrvtId', 'Othr');
         r(creditorScheme, 'Id', this.creditorId);
         r(creditorScheme, 'SchmeNm', 'Prtry', 'SEPA');
+
+        if (this.originalCreditorId) {
+          var originalCreditorScheme = n(pmtInf, 'OrgnlCdtrSchmeId', 'Id', 'PrvtId', 'Othr');
+          r(originalCreditorScheme, 'Id', this.originalCreditorId);
+          r(originalCreditorScheme, 'SchmeNm', 'Prtry', 'SEPA');
+        }
       }
 
       for (var i = 0, l = this._payments.length; i < l; ++i) {

--- a/lib/sepa.test.js
+++ b/lib/sepa.test.js
@@ -3,6 +3,7 @@ var xpath = require('xpath');
 
 // The following debtor id is provided by German Bundesbank for testing purposes.
 const A_VALID_CREDITOR_ID = 'DE98ZZZ09999999999';
+const ANOTHER_VALID_CREDITOR_ID = 'IT66ZZZA1B2C3D4E5F6G7H8';
 
 const A_VALID_IBAN = 'DE43500105178994141576';
 
@@ -246,7 +247,7 @@ describe('xml generation for transfer documents', () => {
 
 describe('xml generation for direct debit documents', () => {
   const PAIN_FOR_DIRECT_DEBIT = 'pain.008.001.08';
-  function validDirectDebitDocument({creditorId=A_VALID_CREDITOR_ID}) {
+  function validDirectDebitDocument({creditorId=A_VALID_CREDITOR_ID, originalCreditorId=null}) {
     var doc = new SEPA.Document(PAIN_FOR_DIRECT_DEBIT);
     doc.grpHdr.created = new Date();
 
@@ -254,6 +255,7 @@ describe('xml generation for direct debit documents', () => {
     info.collectionDate = new Date();
     info.creditorIBAN = A_VALID_IBAN;
     info.creditorId = creditorId;
+    info.originalCreditorId = originalCreditorId;
     doc.addPaymentInfo(info);
 
     var tx = info.createTransaction();
@@ -296,6 +298,39 @@ describe('xml generation for direct debit documents', () => {
 
     const creditorId = select('/p:Document/p:CstmrDrctDbtInitn/p:PmtInf/p:Cdtr/p:Id', dom, true);
     expect(creditorId).toBeUndefined();
+  });
+
+  test('includes original creditor id when set', () => {
+    // GIVEN
+    const doc = validDirectDebitDocument({originalCreditorId: ANOTHER_VALID_CREDITOR_ID});
+
+    // WHEN
+    const dom = doc.toXML();
+
+    // THEN
+    const select = xpath.useNamespaces({
+      p: `urn:iso:std:iso:20022:tech:xsd:${PAIN_FOR_DIRECT_DEBIT}`,
+    });
+
+    const originalCreditorId = select('/p:Document/p:CstmrDrctDbtInitn/p:PmtInf/p:OrgnlCdtrSchmeId/p:Id/p:PrvtId/p:Othr/p:Id', dom, true);
+    expect(originalCreditorId).not.toBeUndefined();
+    expect(originalCreditorId.textContent).toBe(ANOTHER_VALID_CREDITOR_ID);
+  });
+
+  test('works without setting original creditor id', () => {
+    // GIVEN
+    const doc = validDirectDebitDocument({originalCreditorId: null});
+
+    // WHEN
+    const dom = doc.toXML();
+
+    // THEN
+    const select = xpath.useNamespaces({
+      p: `urn:iso:std:iso:20022:tech:xsd:${PAIN_FOR_DIRECT_DEBIT}`,
+    });
+
+    const originalCreditorId = select('/p:Document/p:CstmrDrctDbtInitn/p:PmtInf/p:OrgnlCdtrSchmeId', dom, true);
+    expect(originalCreditorId).toBeUndefined();
   });
 
   test('serialized document starts with proper xml declaration', () => {

--- a/types/sepa.d.ts
+++ b/types/sepa.d.ts
@@ -168,6 +168,8 @@ declare module "sepa" {
 
     /** Id assigned to the creditor */
     creditorId: string;
+    /** Original creditor id (optional, for creditor id migrations) */
+    originalCreditorId: string | null;
     /** Name of the creditor */
     creditorName: string;
     /** Street of the creditor */


### PR DESCRIPTION
- Add originalCreditorId property to SepaPaymentInfo class
- Implement XML generation for OrgnlCdtrSchmeId element
- Add validation for originalCreditorId using existing creditor ID validation
- Add comprehensive tests for the new functionality
- Update README documentation with usage example

🤖 Generated with [Claude Code](https://claude.ai/code)